### PR TITLE
clearpad: Don't break when wakeup_gesture toggled during sleep

### DIFF
--- a/drivers/input/touchscreen/clearpad_core.c
+++ b/drivers/input/touchscreen/clearpad_core.c
@@ -469,6 +469,7 @@ struct clearpad_cover_t {
 struct clearpad_wakeup_gesture_t {
 	bool supported;
 	bool enabled;
+	bool engaged;
 	bool lpm_disabled;
 	bool large_panel;
 	unsigned long time_started;
@@ -2311,7 +2312,7 @@ static int clearpad_set_suspend_mode(struct clearpad_t *this)
 
 	dev_dbg(&this->pdev->dev, "%s\n", __func__);
 
-	if (this->wakeup_gesture.enabled) {
+	if (this->wakeup_gesture.engaged) {
 		if (clearpad_is_valid_function(this, SYN_F11_2D)) {
 			rc = clearpad_put_bit(SYNF(this, F11_2D, CTRL, 0x00),
 				XY_REPORTING_MODE_WAKEUP_GESTURE_MODE,
@@ -2335,7 +2336,7 @@ static int clearpad_set_suspend_mode(struct clearpad_t *this)
 				"failed to enter wake-up gesture mode\n");
 			goto exit;
 		}
-
+		this->wakeup_gesture.enabled = true;
 		this->wakeup_gesture.time_started = jiffies - 1;
 		usleep_range(10000, 11000);
 		LOG_CHECK(this, "enter doze mode\n");
@@ -2353,6 +2354,7 @@ static int clearpad_set_suspend_mode(struct clearpad_t *this)
 				"failed to exit normal mode\n");
 			goto exit;
 		}
+		this->wakeup_gesture.enabled = false;
 		usleep_range(10000, 11000);
 		clearpad_set_irq(this, this->pdt[SYN_F01_RMI].irq_mask, false);
 		LOG_CHECK(this, "enter sleep mode\n");
@@ -3948,13 +3950,13 @@ static ssize_t clearpad_wakeup_gesture_store(struct device *dev,
 		goto exit;
 	}
 
-	this->wakeup_gesture.enabled = sysfs_streq(buf, "0") ? false : true;
+	this->wakeup_gesture.engaged = sysfs_streq(buf, "0") ? false : true;
 
 	device_init_wakeup(&this->pdev->dev,
-			this->wakeup_gesture.enabled ? 1 : 0);
+			this->wakeup_gesture.engaged ? 1 : 0);
 
 	dev_info(&this->pdev->dev, "wakeup gesture: %s",
-			this->wakeup_gesture.enabled ? "ENABLE" : "DISABLE");
+			this->wakeup_gesture.engaged ? "ENABLE" : "DISABLE");
 exit:
 	UNLOCK(this);
 


### PR DESCRIPTION
Let the wakeup_gesture attribute affect the next suspend of the
touchscreen, so that if wakeup_gesture is toggled while the touchscreen
is suspended, the driver/touchscreen doesn't get confused (because the
driver wakes it up assuming it is in normal suspend, but the touchscreen
is in tap-to-wake mode -- or vice versa).

This fixes the problem where phone calls cannot be answered with
tap-to-wake on.

Change-Id: I7fa5a826e84bd4a4b6cd25b8c249d2e83c628d3f
Signed-off-by: angelsl hidingfromhidden@gmail.com
